### PR TITLE
Fixed case where align would fail on last line

### DIFF
--- a/main.js
+++ b/main.js
@@ -79,6 +79,11 @@ define(function (require, exports, module) {
 
             // Get text range
             var range = e.document.getRange(selection.start, selection.end);
+            // Check if selection ends on last line
+            if(selection.end.line >= e.lineCount()) {
+                // If so add extra newline
+                range += '\n';
+            }
             // Process text range
             var result = align(range);
             // Replace text range with processed one


### PR DESCRIPTION
Previously trying use the alignment feature on the last line deleted the last line.

Just something I noticed while using your extension. Figured I might as well send my fix along.

The problem was that the `String.match` in your `align` function wasn't accounting for the fact that the last line in the file won't have a new line after it.

I didn't want to change too much of your code so I tried to keep the changes minimal, resulting in not the cleanest fix, but it works.
